### PR TITLE
Proposal: `render` method for an MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1,37 +1,47 @@
-import { Server, ServerOptions } from './index.js'
-import { zodToJsonSchema } from 'zod-to-json-schema'
-import { AnyZodObject, z, ZodObject, ZodOptional, ZodRawShape, ZodString, ZodType, ZodTypeAny, ZodTypeDef } from 'zod'
+import { Server, ServerOptions } from "./index.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import {
-  CallToolRequestSchema,
-  CallToolResult,
-  CompleteRequest,
-  CompleteRequestSchema,
-  CompleteResult,
-  ErrorCode,
-  GetPromptRequestSchema,
-  GetPromptResult,
+  z,
+  ZodRawShape,
+  ZodObject,
+  ZodString,
+  AnyZodObject,
+  ZodTypeAny,
+  ZodType,
+  ZodTypeDef,
+  ZodOptional,
+} from "zod";
+import {
   Implementation,
-  ListPromptsRequestSchema,
-  ListPromptsResult,
-  ListResourcesRequestSchema,
+  Tool,
+  ListToolsResult,
+  CallToolResult,
+  McpError,
+  ErrorCode,
+  CompleteRequest,
+  CompleteResult,
+  PromptReference,
+  ResourceReference,
+  Resource,
   ListResourcesResult,
   ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
   ListToolsRequestSchema,
-  ListToolsResult,
-  McpError,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+  CompleteRequestSchema,
+  ListPromptsResult,
   Prompt,
   PromptArgument,
-  PromptReference,
-  ReadResourceRequestSchema,
+  GetPromptResult,
   ReadResourceResult,
-  Resource,
-  ResourceReference,
-  Tool
-} from '../types.js'
-import { Completable, CompletableDef } from './completable.js'
-import { UriTemplate, Variables } from '../shared/uriTemplate.js'
-import { RequestHandlerExtra } from '../shared/protocol.js'
-import { Transport } from '../shared/transport.js'
+} from "../types.js";
+import { Completable, CompletableDef } from "./completable.js";
+import { UriTemplate, Variables } from "../shared/uriTemplate.js";
+import { RequestHandlerExtra } from "../shared/protocol.js";
+import { Transport } from "../shared/transport.js";
 
 type RenderApi = {
   resource: McpServer["resource"];

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -42,7 +42,6 @@ type RenderApi = {
 type McpServerOptions<T extends Record<string, any> = Record<string, any>> =
   ServerOptions & {
   render?: (api: RenderApi, args: T) => void | Promise<void>;
-  locked?: boolean;
 };
 
 /**
@@ -73,13 +72,7 @@ export class McpServer<RenderArgs extends Record<string, any> = Record<string, a
   constructor(serverInfo: Implementation, options?: McpServerOptions<RenderArgs>) {
     this.server = new Server(serverInfo, options);
     this._renderFunction = options?.render;
-    this._locked = options?.locked ?? false;
-
-    if (this._locked && !this._renderFunction) {
-      throw new Error(
-        "McpServer is locked, but no render function was provided. No resources, tools, or prompts can be registered.",
-      );
-    }
+    this._locked = Boolean(this._renderFunction);
   }
 
   /**


### PR DESCRIPTION
Currently, the design of the `McpServer` makes it easy to define servers whose resources/tools/prompts are static and known ahead of time:

```ts
const server = new McpServer({ name: '...', version: '1.0.0' })

// Attach prompts/resources/tools to the server before opening to connections
server.resource(`counter`, `mcp://resource/counter`, (uri) => {
  return { contents: [{ uri: uri.href, text: String(1) }] }
})
server.tool('add', { a: z.number(), b: z.number() }, async ({ a, b }) => ({
  content: [{ type: 'text', text: String(a + b) }],
}))
server.prompt('review-code', { code: z.string() }, ({ code }) => ({
  messages: [{ role: 'user', content: { type: 'text', text: `Please review this code:\n\n${code}` } }],
}))

// Connect to transport
await server.connect(transport)
```

There's nothing stopping you from adding tools/prompts/resources after connecting, but it also doesn't broadcast `list_changed` events if you were to do so. So there's not really a good way to make a "dynamic" `McpServer` without dropping down a level and building your own abstraction using a `Server`.

I've been looking for a neat API which can make these servers dynamic without needing a complete restructure of the class. This is the best I've come up with: adding the concept of a `render` function where the output is diffed to the previous version to emit change events:

```ts
const server = new McpServer(
  {
    name: '...',
    version: '1.0.0',
  },
  {
    // This function describes the total surface area of the McpServer. 
    // Nothing can be added outside of it
    render: ({ resource, tool, prompt }) => {
      resource(`counter`, `mcp://resource/counter`, /* ... */)
      tool('add', { a: z.number(), b: z.number() }, , /* ... */)
      prompt('review-code', { code: z.string() }, /* ... */)
    },
  },
)

// Call render at least once before connecting
server.render()
// Connect as normal
await server.connect(transport)

// Rerunning render recalculates the whole McpServer, and emits events if anything change
server.render()
```

As written, the `render()` function could observe some external state to choose to hide/show/tweak aspects of the server, but I think it makes more sense if `render` takes an argument:

```ts
type RenderArgs = {
  state: 'loading' | 'loaded'
  userTier: 'free' | 'paid'
}

const server = new McpServer<RenderArgs>(
  {
    name: '...',
    version: '1.0.0',
  },
  {
    render: ({ resource, tool, prompt }, args) => {
      prompt('review-code', { code: z.string() }, /* ... */)

      if (args.state === 'loading') return

      resource(`counter`, `mcp://resource/counter`, /* ... */)

      if (args.userTier === 'paid') {
        tool('add', { a: z.number(), b: z.number() }, , /* ... */)
      }
    },
  },
)

server.render({ state: 'loading' })
server.connect(transport)

const user = await loadUser()
// Emits relevant update events automatically
server.render({ state: 'loaded', userTier: user.tier })
```

This feels like the most natural way to take the current API and make it dynamic, though there's plenty of alternatives.

Anyway, I thought I'd raise this as a draft PR to see if there was any interest in the API itself, before I finish it off. Currently it needs a smarter diffing algorithm (currently only looks for things being added/removed, but a change of description should probably fire an event too), as well as some tests.